### PR TITLE
Coding standards

### DIFF
--- a/snort-mode.el
+++ b/snort-mode.el
@@ -18,14 +18,19 @@
 
 ;;; Code;
 
-(defcustom snort-basic-offset 4 "Snort identation level.")
+(defgroup snort nil
+  "Major mode for editing Snort rules")
+
+(defcustom snort-basic-offset 4
+  "Snort identation level."
+  :type 'integer
+  :group 'snort)
 
 (defvar snort-mode-map
   (let ((map (make-sparse-keymap)))
     (define-key map "C-j" 'newline-and-indent)
     map)
   "Keymap for Snort major mode")
-
 
 (defvar snort-actions
   '("alert" "log" "pass" "activate" "dynamic" "drop" "reject" "sdrop" "ruletype"
@@ -43,8 +48,8 @@
     "icmp_id" "icmp_seq" "rpc" "ip_proto" "sameip" "stream_reassemble" "stream_size"
     "logto" "session" "resp" "react" "tag" "activates" "activated_by" "replace" "detection_filter"
     "treshold")
-  "Rule modifiers, basically everything that can have ":" behind
-  it - and some without arguments")
+  "Rule modifiers are everything which can have the suffix ":"
+Some without arguments.")
 
 (defvar snort-keywords
   '("tcp" "udp" "icmp" "ip" "hex" "dec" "oct" "string" "type" "output" "any" "engine" "soid" "service"
@@ -68,7 +73,6 @@
 (defvar snort-end-of-rule-regexp ".*)\\s-*$")
 (defvar snort-multiline-regexp ".*\\\\\\s-*$")
 (defvar snort-ruletype-regexp "\\(ruletype\\|{\\|}\\)")
-
 
 (defvar snort-font-lock-keywords
   `(
@@ -123,7 +127,6 @@
   (save-excursion
     (beginning-of-line)
     (looking-at "^\\s-*\\(ruletype\\|{\\|}\\)")))
-
 
 (defun snort-next-rule (&optional n)
   "Move to the beginning of the next rule."
@@ -190,6 +193,7 @@
 ;;;###autoload
 (define-derived-mode snort-mode prog-mode
   "Snort" "A major mode for editing Snort rules."
+  :group 'snort
   ;; (set-syntax-table snort-mode-syntax-table)
   (set (make-local-variable 'font-lock-defaults) '(snort-font-lock-keywords))
   (set (make-local-variable 'indent-line-function) 'snort-indent-line)

--- a/snort-mode.el
+++ b/snort-mode.el
@@ -1,4 +1,4 @@
-;; snort-mode - major mode for editing Snort rules
+;;; snort-mode.el --- major mode for editing Snort rules
 
 ;; Author: Øyvind Ingvaldsen <oyvind.ingvaldsen@gmail.com>
 ;; Edited: <2012-12-04 Tue>

--- a/snort-mode.el
+++ b/snort-mode.el
@@ -187,20 +187,12 @@
                     "-q")
       (goto-char (point-max)))))
 
-(define-derived-mode snort-mode fundamental-mode
-  "snort-mode"
-  "A major mode for editing Snort rules."
-  (kill-all-local-variables)
-
-  (use-local-map snort-mode-map)
-  ; (set-syntax-table snort-mode-syntax-table)
+(define-derived-mode snort-mode prog-mode
+  "Snort" "A major mode for editing Snort rules."
+  ;; (set-syntax-table snort-mode-syntax-table)
   (set (make-local-variable 'font-lock-defaults) '(snort-font-lock-keywords))
   (set (make-local-variable 'indent-line-function) 'snort-indent-line)
-
-  (setq major-mode 'snort-mode)
-  (setq mode-name "Snort")
-  (setq comment-start "#")
-  (run-hooks 'snort-mode-hook))
+  (setq comment-start "#"))
 
 (provide 'snort-mode)
 

--- a/snort-mode.el
+++ b/snort-mode.el
@@ -2,67 +2,60 @@
 
 ;; Author: Øyvind Ingvaldsen <oyvind.ingvaldsen@gmail.com>
 ;; Edited: <2012-12-04 Tue>
-;; Source: 
+;; Source:
 
 ;; Todo:
-;; - Remove word lists when regexp are created? (free memory) 
-;; - Does not support user created rule actions 
-;; - Variable modifiers 
+;; - Remove word lists when regexp are created? (free memory)
+;; - Does not support user created rule actions
+;; - Variable modifiers
 ;; - Syntax table
 
-
-;; give people something to hook
-(defvar snort-mode-hook nil)
-
-;; default indent level
 (defcustom snort-basic-offset 4 "Snort identation level.")
 
-;; setup keys
+
 (defvar snort-mode-map
   (let ((map (make-sparse-keymap)))
     (define-key map "C-j" 'newline-and-indent)
     map)
   "Keymap for Snort major mode")
 
-;; actions 
+
 (defvar snort-actions
   '("alert" "log" "pass" "activate" "dynamic" "drop" "reject" "sdrop" "ruletype"
     "var" "portvar" "ipvar"))
 
-;; rule modifiers (basically everthing that can have ":" behind it - and some without arguments )
 (defvar snort-modifiers
-  '("msg" "reference" "gid" "sid" "rev" "classtype" "priority" "metadata" "content" "http_encode" 
-    "uricontent" "urilen" "isdataat" "pcre" "pkt_data" "file_data" "base64_decode" "base64_data" 
-    "byte_test" "byte_jump" "byte_extract" "ftp_bounce" "pcre" "asn1" "cvs" "dce_iface" "dce_opnum" 
+  '("msg" "reference" "gid" "sid" "rev" "classtype" "priority" "metadata" "content" "http_encode"
+    "uricontent" "urilen" "isdataat" "pcre" "pkt_data" "file_data" "base64_decode" "base64_data"
+    "byte_test" "byte_jump" "byte_extract" "ftp_bounce" "pcre" "asn1" "cvs" "dce_iface" "dce_opnum"
     "dce_stub_data" "sip_method" "sip_stat_code" "sip_header" "sip_body" "gtp_type" "gtp_info"
-    "gtp_version" "ssl_version" "ssl_state" "nocase" "rawbytes" "depth" "offset" "distance" "within" 
+    "gtp_version" "ssl_version" "ssl_state" "nocase" "rawbytes" "depth" "offset" "distance" "within"
     "http_client_body" "http_cookie" "http_raw_cookie" "http_header" "http_raw_header" "http_method"
-    "http_uri" "http_raw_uri" "http_stat_code" "http_stat_msg" "fast_pattern" "fragoffset" "fragbits" 
-    "ttl" "tos" "id" "ipopts" "dsize" "flags" "flow" "flowbits" "seq" "ack" "window" "itype" "icode" 
+    "http_uri" "http_raw_uri" "http_stat_code" "http_stat_msg" "fast_pattern" "fragoffset" "fragbits"
+    "ttl" "tos" "id" "ipopts" "dsize" "flags" "flow" "flowbits" "seq" "ack" "window" "itype" "icode"
     "icmp_id" "icmp_seq" "rpc" "ip_proto" "sameip" "stream_reassemble" "stream_size"
     "logto" "session" "resp" "react" "tag" "activates" "activated_by" "replace" "detection_filter"
-    "treshold"))
+    "treshold")
+  "Rule modifiers, basically everything that can have ":" behind
+  it - and some without arguments")
 
-;; keywords (arguments to modifiers)
 (defvar snort-keywords
-  '("tcp" "udp" "icmp" "ip" "hex" "dec" "oct" "string" "type" "output" "any" "engine" "soid" "service" 
+  '("tcp" "udp" "icmp" "ip" "hex" "dec" "oct" "string" "type" "output" "any" "engine" "soid" "service"
     "norm" "raw" "relative" "bytes" "big" "little" "align" "invalid-entry" "enable" "disable" "client" "server"
-    "both" "either" "printable" "binary" "all" "session" "host" "packets" "seconds" "bytes" "src" "dst" "track" 
-    "by_src" "by_dst" "uri" "header" "cookie" "utf8" "double_encode" "non_ascii" "uencode" "bare_byte" "ascii" 
+    "both" "either" "printable" "binary" "all" "session" "host" "packets" "seconds" "bytes" "src" "dst" "track"
+    "by_src" "by_dst" "uri" "header" "cookie" "utf8" "double_encode" "non_ascii" "uencode" "bare_byte" "ascii"
     "iis_encode" "bitstring_overflow" "double_overflow" "oversize_length" "absolute_offset" "relative_offset"
-    "rr" "eol" "nop" "ts" "sec" "esec" "lsrr" "lsrre" "ssrr" "satid" "to_client" "to_server" "from_client" 
+    "rr" "eol" "nop" "ts" "sec" "esec" "lsrr" "lsrre" "ssrr" "satid" "to_client" "to_server" "from_client"
     "from_server" "established" "not_established" "stateless" "no_stream" "only_stream" "no_frag" "only_frag"
     "set" "setx" "unset" "toggle" "isset" "isnotset" "noalert" "limit" "treshold" "count" "str_offset" "str_depth"
-    "tagged"))
+    "tagged")
+  "arguments to modifiers")
 
-
-;; regular expressions
 (defvar snort-actions-regexp (regexp-opt snort-actions 'words))
 (defvar snort-modifiers-regexp (regexp-opt snort-modifiers 'words))
 (defvar snort-keywords-regexp (regexp-opt snort-keywords 'words))
 (defvar snort-comments-regexp "\\(^\\|\\s-\\)\\#.*")
 (defvar snort-variables-regexp "\\(^\\| \\)\\$\\(\\sw\\|\\s_\\)+")
-
 
 (defvar snort-beginning-of-rule-regexp (concat "^\\s-*" snort-actions-regexp))
 (defvar snort-end-of-rule-regexp ".*)\\s-*$")
@@ -154,7 +147,7 @@
 (defun snort-validate ()
   "Validate the syntax of the current Snort-file."
   (interactive)
-  (with-output-to-temp-buffer "*snort*" 
+  (with-output-to-temp-buffer "*snort*"
     (princ "[snort-mode] Validating buffer\n")
     (let ((conf-file (concat (file-name-nondirectory buffer-file-name) ".conf")))
       (if (not (file-exists-p conf-file))
@@ -163,12 +156,12 @@
             (prin1 conf-file)
             (princ "\n")
             (snort-create-config-for-current-file))
-        (princ "[snort-mode] Using config file: ") 
+        (princ "[snort-mode] Using config file: ")
         (prin1 conf-file)
         (princ "\n"))
       (princ "[snort-mode] Starting Snort\n")
-      (call-process "snort" nil "*snort*" nil 
-                    "-c" conf-file 
+      (call-process "snort" nil "*snort*" nil
+                    "-c" conf-file
                     "-T")
       (switch-to-buffer-other-window "*snort*")
       (goto-char (point-max)))))
@@ -176,7 +169,7 @@
 (defun snort-test-pcap (pcap)
   "Test rules against a PCAP."
   (interactive "fChoose PCAP-file: ")
-  (with-output-to-temp-buffer "*snort*" 
+  (with-output-to-temp-buffer "*snort*"
     (princ "[snort-mode] Validating buffer\n")
     (let ((conf-file (concat (file-name-nondirectory buffer-file-name) ".conf"))
           (pcap-file pcap))
@@ -189,20 +182,18 @@
             (prin1 conf-file)
             (princ "\n")
             (snort-create-config-for-current-file))
-        (princ "[snort-mode] Using config file: ") 
+        (princ "[snort-mode] Using config file: ")
         (prin1 conf-file)
         (princ "\n"))
       (princ "[snort-mode] Starting Snort\n")
       (switch-to-buffer-other-window "*snort*")
-      (call-process "snort" nil "*snort*" nil 
-                    "-c" conf-file 
-                    "-r" (expand-file-name pcap-file) 
+      (call-process "snort" nil "*snort*" nil
+                    "-c" conf-file
+                    "-r" (expand-file-name pcap-file)
                     "-A" "console"
                     "-q")
       (goto-char (point-max)))))
 
-
-;; define the mode
 (define-derived-mode snort-mode fundamental-mode
   "snort-mode"
   "A major mode for editing Snort rules."
@@ -219,4 +210,3 @@
   (run-hooks 'snort-mode-hook))
 
 (provide 'snort-mode)
-

--- a/snort-mode.el
+++ b/snort-mode.el
@@ -2,6 +2,7 @@
 
 ;; Author: Øyvind Ingvaldsen <oyvind.ingvaldsen@gmail.com>
 ;; Edited: <2012-12-04 Tue>
+;; Version: 1.0
 ;; Source:
 
 ;; Todo:

--- a/snort-mode.el
+++ b/snort-mode.el
@@ -79,10 +79,6 @@
     (,snort-variables-regexp . font-lock-variable-name-face)
     ))
 
-
-(defun snort-set-offset offset
-  (setq snort-set-basic-offset offset))
-
 (defun snort-indent-line ()
   "Indent current line of Snort code."
   (interactive)

--- a/snort-mode.el
+++ b/snort-mode.el
@@ -187,6 +187,7 @@
                     "-q")
       (goto-char (point-max)))))
 
+;;;###autoload
 (define-derived-mode snort-mode prog-mode
   "Snort" "A major mode for editing Snort rules."
   ;; (set-syntax-table snort-mode-syntax-table)

--- a/snort-mode.el
+++ b/snort-mode.el
@@ -1,18 +1,24 @@
-;;; snort-mode.el --- major mode for editing Snort rules
+;;; snort-mode.el --- Major mode for editing Snort rules
 
 ;; Author: Øyvind Ingvaldsen <oyvind.ingvaldsen@gmail.com>
 ;; Edited: <2012-12-04 Tue>
 ;; Version: 1.0
-;; Source:
 
-;; Todo:
+;;; Todo:
 ;; - Remove word lists when regexp are created? (free memory)
 ;; - Does not support user created rule actions
 ;; - Variable modifiers
 ;; - Syntax table
 
-(defcustom snort-basic-offset 4 "Snort identation level.")
+;;; Commentary:
 
+;; Here are some of the things which `snort-mode' lets you do:
+;;
+;; TODO: Add some examples.
+
+;;; Code;
+
+(defcustom snort-basic-offset 4 "Snort identation level.")
 
 (defvar snort-mode-map
   (let ((map (make-sparse-keymap)))

--- a/snort-mode.el
+++ b/snort-mode.el
@@ -217,3 +217,5 @@
   (run-hooks 'snort-mode-hook))
 
 (provide 'snort-mode)
+
+;;; snort-mode.el ends here


### PR DESCRIPTION
A number of coding-standard improvements. See each commit for a description.

As I do not have Snort installed, you should probably test `snort-test-pcap` to ensure it still functions correctly.
